### PR TITLE
Backport some httping improvements to gotcping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,25 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# Custom
 gotcping

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ gotcping uses the awesome [stats](https://github.com/montanaflynn/stats)  librar
 ### Defaults
 
     -port default to 80
-    -count defaults to 10 probes
+    -count defaults to 10 probes [0 means infinite]
     -timeout defaults to 1 second
 
 ### Example

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ func main() {
 
 	hostPtr := flag.String("host", "", "Host or IP address to test")
 	portPtr := flag.Int("port", 80, "Port number to query")
-	countPtr := flag.Int("count", 10, "Number of requests to send")
+	countPtr := flag.Int("count", 10, "Number of requests to send [0 means infinite]")
 	timeoutPtr := flag.Int("timeout", 1, "Timeout for each request, in seconds")
 	var host string
 
@@ -53,7 +53,7 @@ func ping(host string, port int, count int, timeout int) {
 
 	addr := fmt.Sprintf("%s:%d", host, port)
 
-	for i = 1; count >= i; i++ {
+	for i = 1; (count >= i || count < 1); i++ {
 		timeStart := time.Now()
 		_, err := net.DialTimeout("tcp", addr, time.Second*time.Duration(timeout))
 		responseTime := time.Since(timeStart)
@@ -66,7 +66,11 @@ func ping(host string, port int, count int, timeout int) {
 			responseTimes = append(responseTimes, float64(responseTime))
 		}
 
-		time.Sleep(time.Second - responseTime)
+		// Don't sleep after the last needed ping, so results can be displayed 1 second faster
+		// (quick mathematics are cheap, 1 second is long)
+		if ((count-i) > 1) || (count <= 0) {
+			time.Sleep(time.Second - responseTime)
+		}
 	}
 
 	// Print results


### PR DESCRIPTION
I backported some httping improvements to gotcping . Changes,

1. Continuous (htt)ping support (infinite pings) - similar to httping's [#11](https://github.com/pjperez/httping/pull/11) 
    * In some cases, application needs to run infinitely. You can read more about Continuous Ping [here](https://www.ionos.com/digitalguide/server/tools/continuous-ping/) .

2. Change - Don't sleep after the last needed ping - see httping's [#12](https://github.com/pjperez/httping/pull/12) 
    * The change in this Push Request removes unnecessary **sleep 1s** , making user wait less. This is the same behavior as in standard ping.

3. Update `.gitignore`

I tested the changes, too.

