### PR TITLE
Security follow-ups: bounded samples, deadline/SIGTERM, sanitization, CI, tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go build
+        run: go build ./...
+
+      - name: go test
+        run: go test ./...
+
+      - name: govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ gotcping uses the awesome [stats](https://github.com/montanaflynn/stats)  librar
 ## Installing
 ### From source
 
-    go get github.com/pjperez/gotcping
+    go install github.com/pjperez/gotcping@latest
+
+### Running from source without installing
+
+    go run github.com/pjperez/gotcping@latest <args>
 
 ## Binaries
 
@@ -20,7 +24,7 @@ gotcping uses the awesome [stats](https://github.com/montanaflynn/stats)  librar
 
 ## Usage
 
-    gotcping -host host [-port port_number] [-count number_of_repetitions] [-timeout timeout_in_seconds]
+    gotcping -host host [-port port_number] [-count number_of_repetitions] [-timeout timeout_in_seconds] [-deadline max_seconds]
 
 ### Alternate (only host is mandatory and can be specified either as a flag or as an argument)
 
@@ -29,8 +33,9 @@ gotcping uses the awesome [stats](https://github.com/montanaflynn/stats)  librar
 ### Defaults
 
     -port default to 80
-    -count defaults to 10 probes [0 means infinite]
+    -count defaults to 10 probes [0 or negative means infinite]
     -timeout defaults to 1 second
+    -deadline defaults to 0 (no deadline; in infinite mode use Ctrl+C to stop and still print results)
 
 ### Example
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gotcping
+module github.com/pjperez/gotcping
 
 go 1.25.10
 

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/montanaflynn/stats"
@@ -21,11 +22,16 @@ const (
 	exitAllFailed     = 3
 )
 
+// maxSamples caps how many RTT samples are retained for statistics. In
+// infinite mode this bounds memory; for typical finite runs it is never hit.
+const maxSamples = 100000
+
 func main() {
 	hostPtr := flag.String("host", "", "Host or IP address to test")
 	portPtr := flag.Int("port", 80, "Port number to query (1-65535)")
-	countPtr := flag.Int("count", 10, "Number of requests to send [0 means infinite]")
+	countPtr := flag.Int("count", 10, "Number of requests to send [0 or negative means infinite]")
 	timeoutPtr := flag.Int("timeout", 1, "Timeout for each request, in seconds (>=1)")
+	deadlinePtr := flag.Int("deadline", 0, "Stop after this many seconds regardless of count [0 means no deadline]")
 
 	flag.Parse()
 
@@ -42,137 +48,217 @@ func main() {
 	port := *portPtr
 	count := *countPtr
 	timeout := *timeoutPtr
+	deadline := *deadlinePtr
 
 	if host == "" {
 		flag.Usage()
 		os.Exit(exitUsage)
 	}
-	// H1: validate port range before it reaches net.Dial.
-	if port < 1 || port > 65535 {
-		fmt.Fprintf(os.Stderr, "error: port must be between 1 and 65535 (got %d)\n", port)
+	if err := validatePort(port); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
 		os.Exit(exitUsage)
 	}
-	// H2: a non-positive timeout disables the dial timeout entirely on most
-	// platforms, so enforce a sane lower bound.
-	if timeout < 1 {
-		fmt.Fprintf(os.Stderr, "error: timeout must be at least 1 second (got %d)\n", timeout)
+	if err := validateTimeout(timeout); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(exitUsage)
+	}
+	if err := validateDeadline(deadline); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
 		os.Exit(exitUsage)
 	}
 
-	// H3: resolve once and dial the resulting IP, so the host we validate is
-	// the host we actually connect to (avoids DNS-rebinding TOCTOU between a
+	// Resolve once and dial the resulting IP, so the host we validate is the
+	// host we actually connect to (avoids DNS-rebinding TOCTOU between a
 	// validation lookup and the dial, and re-resolution per probe).
-	ips, err := net.LookupIP(host)
-	if err != nil || len(ips) == 0 {
+	resolvedIP, err := resolveHost(host)
+	if err != nil {
 		fmt.Printf("error: can't resolve %s\n", host)
 		os.Exit(exitResolveFailed)
 	}
-	resolvedIP := ips[0].String()
 
-	ping(host, resolvedIP, port, count, timeout)
+	ping(sanitize(host), resolvedIP, port, count, timeout, deadline)
 }
 
-func ping(displayHost, resolvedIP string, port int, count int, timeout int) {
+// validatePort returns an error if p is outside the valid TCP port range.
+func validatePort(p int) error {
+	if p < 1 || p > 65535 {
+		return fmt.Errorf("port must be between 1 and 65535 (got %d)", p)
+	}
+	return nil
+}
+
+// validateTimeout enforces a positive dial timeout. A non-positive timeout
+// disables the dial timeout on most platforms, defeating the tool's own DoS
+// protection and hanging the process.
+func validateTimeout(t int) error {
+	if t < 1 {
+		return fmt.Errorf("timeout must be at least 1 second (got %d)", t)
+	}
+	return nil
+}
+
+// validateDeadline enforces a non-negative deadline.
+func validateDeadline(d int) error {
+	if d < 0 {
+		return fmt.Errorf("deadline must be >= 0 seconds (got %d)", d)
+	}
+	return nil
+}
+
+// resolveHost resolves host to a single IP string (the first result).
+func resolveHost(host string) (string, error) {
+	ips, err := net.LookupIP(host)
+	if err != nil || len(ips) == 0 {
+		return "", fmt.Errorf("can't resolve %s", host)
+	}
+	return ips[0].String(), nil
+}
+
+// sanitize replaces terminal control characters with '?' so an attacker
+// controlled hostname cannot forge log lines or inject ANSI sequences into
+// the tool's output.
+func sanitize(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return '?'
+		}
+		return r
+	}, s)
+}
+
+func ping(displayHost, resolvedIP string, port int, count int, timeout int, deadline int) {
+	attempts := 0
 	successfulProbes := 0
-	i := 1
-	timeTotal := time.Duration(0)
-	var responseTimes []float64
+	ring := newSampleRing(maxSamples)
 
 	// net.JoinHostPort correctly brackets IPv6 literals (also clears the
 	// `go vet` "address format does not work with IPv6" warning).
 	addr := net.JoinHostPort(resolvedIP, strconv.Itoa(port))
 
-	// In infinite mode (count < 1), allow Ctrl+C / SIGTERM to stop and still
-	// print results.
+	// Always allow Ctrl+C / SIGTERM (or a deadline) to stop and still print
+	// results, for both finite and infinite runs.
 	stop := make(chan os.Signal, 1)
-	if count < 1 {
-		signal.Notify(stop, os.Interrupt)
-	}
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 	defer signal.Stop(stop)
 
-	for i = 1; (count >= i || count < 1); i++ {
-		if count < 1 {
-			select {
-			case <-stop:
-				// i is the probe that was about to start; report i-1 sent.
-				output(successfulProbes, timeTotal, displayHost, port, responseTimes, i)
-				os.Exit(exitOK)
-			default:
-			}
+	var deadlineCh <-chan time.Time
+	if deadline > 0 {
+		deadlineCh = time.After(time.Duration(deadline) * time.Second)
+	}
+
+loop:
+	for {
+		if count >= 1 && attempts >= count {
+			break
+		}
+		select {
+		case <-stop:
+			break loop
+		case <-deadlineCh:
+			break loop
+		default:
 		}
 
+		attempts++
 		timeStart := time.Now()
 		_, err := net.DialTimeout("tcp", addr, time.Second*time.Duration(timeout))
 		responseTime := time.Since(timeStart)
 		if err != nil {
 			fmt.Printf("Received timeout while connecting to %s on port %d.\n", displayHost, port)
 		} else {
-			fmt.Printf("Probe %v: Connected to %s:%d, RTT=%.2fms\n", i, displayHost, port, float64(responseTime.Nanoseconds())/1e6)
-			timeTotal += responseTime
+			fmt.Printf("Probe %v: Connected to %s:%d, RTT=%.2fms\n", attempts, displayHost, port, float64(responseTime.Nanoseconds())/1e6)
 			successfulProbes++
-			responseTimes = append(responseTimes, float64(responseTime))
+			ring.add(float64(responseTime))
 		}
 
-		// Don't sleep after the last needed ping, so results can be displayed 1 second faster
-		// (quick mathematics are cheap, 1 second is long)
-		if (count-i) > 0 || count <= 0 {
-			if count < 1 {
-				// Interruptible sleep so Ctrl+C is responsive.
-				select {
-				case <-stop:
-					// Last completed probe is i; report i probes sent.
-					output(successfulProbes, timeTotal, displayHost, port, responseTimes, i+1)
-					os.Exit(exitOK)
-				case <-time.After(time.Second - responseTime):
-				}
-			} else {
-				time.Sleep(time.Second - responseTime)
+		// Don't sleep after the last probe of a finite run, so results are
+		// displayed ~1 second faster.
+		if count < 1 || attempts < count {
+			select {
+			case <-stop:
+				break loop
+			case <-deadlineCh:
+				break loop
+			case <-time.After(time.Second - responseTime):
 			}
 		}
 	}
 
-	// Print results
-	output(successfulProbes, timeTotal, displayHost, port, responseTimes, i)
+	output(attempts, successfulProbes, ring.values(), displayHost, port)
 }
 
-func output(successfulProbes int, timeTotal time.Duration, host string, port int, responseTimes []float64, i int) {
-	// Let's calculate and spill some results
-	// 1. Average response time
-	timeAverage := time.Duration(0)
-	if successfulProbes > 0 {
-		timeAverage = time.Duration(int64(timeTotal) / int64(successfulProbes))
-	} else {
+// sampleRing is a fixed-capacity ring buffer of float64 samples. Once full,
+// new samples overwrite the oldest. values() returns the current contents in
+// insertion order.
+type sampleRing struct {
+	buf  []float64
+	cap  int
+	head int
+	full bool
+}
+
+func newSampleRing(c int) *sampleRing {
+	if c < 1 {
+		c = 1
+	}
+	return &sampleRing{cap: c}
+}
+
+func (r *sampleRing) add(v float64) {
+	if !r.full {
+		if len(r.buf) < r.cap {
+			r.buf = append(r.buf, v)
+			return
+		}
+		r.full = true
+	}
+	r.buf[r.head] = v
+	r.head++
+	if r.head == r.cap {
+		r.head = 0
+	}
+}
+
+func (r *sampleRing) values() []float64 {
+	if !r.full {
+		return r.buf
+	}
+	out := make([]float64, r.cap)
+	n := copy(out, r.buf[r.head:])
+	copy(out[n:], r.buf[:r.head])
+	return out
+}
+
+func output(attempts, successfulProbes int, samples []float64, host string, port int) {
+	probesSent := attempts
+	if successfulProbes == 0 {
 		fmt.Printf("\nAll the requests have failed. The host %s is not replying to connections on %d\n", host, port)
 		os.Exit(exitAllFailed)
 	}
-	// 2. Min and Max response times
-	var biggest float64
+	percentFailed := 100 - (float64(successfulProbes)*100)/float64(probesSent)
 
-	smallest := float64(1000000000)
-
-	for _, v := range responseTimes {
-
-		if v > biggest {
-			biggest = v
-		}
-
+	// Statistics below are computed over the retained sample window. For
+	// finite runs this is all probes; for very long infinite runs it is the
+	// most recent maxSamples probes.
+	sum := 0.0
+	smallest := samples[0]
+	biggest := samples[0]
+	for _, v := range samples {
+		sum += v
 		if v < smallest {
 			smallest = v
 		}
-
+		if v > biggest {
+			biggest = v
+		}
 	}
+	timeAverage := time.Duration(sum / float64(len(samples)))
 
-	// 3. Median response time
-	median, _ := stats.Median(responseTimes)
-
-	// 4. Percentile
-	percentile90, _ := stats.Percentile(responseTimes, float64(90))
-	percentile75, _ := stats.Percentile(responseTimes, float64(75))
-	percentile50, _ := stats.Percentile(responseTimes, float64(50))
-	percentile25, _ := stats.Percentile(responseTimes, float64(25))
-
-	probesSent := i - 1
-	percentFailed := 100 - (float64(successfulProbes)*100)/float64(probesSent)
+	median, _ := stats.Median(samples)
+	percentile90, _ := stats.Percentile(samples, 90)
+	percentile75, _ := stats.Percentile(samples, 75)
+	percentile50, _ := stats.Percentile(samples, 50)
+	percentile25, _ := stats.Percentile(samples, 25)
 
 	fmt.Println("\nProbes sent:", probesSent, "\nSuccessful responses:", successfulProbes,
 		"\n% of requests failed:", percentFailed,

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestValidatePort(t *testing.T) {
+	cases := []struct {
+		port int
+		ok   bool
+	}{
+		{0, false}, {-1, false}, {1, true}, {80, true},
+		{65535, true}, {65536, false}, {100000, false},
+	}
+	for _, c := range cases {
+		err := validatePort(c.port)
+		if c.ok && err != nil {
+			t.Errorf("validatePort(%d): expected ok, got %v", c.port, err)
+		}
+		if !c.ok && err == nil {
+			t.Errorf("validatePort(%d): expected error, got nil", c.port)
+		}
+	}
+}
+
+func TestValidateTimeout(t *testing.T) {
+	cases := []struct {
+		t  int
+		ok bool
+	}{
+		{-5, false}, {0, false}, {1, true}, {5, true},
+	}
+	for _, c := range cases {
+		err := validateTimeout(c.t)
+		if c.ok && err != nil {
+			t.Errorf("validateTimeout(%d): expected ok, got %v", c.t, err)
+		}
+		if !c.ok && err == nil {
+			t.Errorf("validateTimeout(%d): expected error, got nil", c.t)
+		}
+	}
+}
+
+func TestValidateDeadline(t *testing.T) {
+	if err := validateDeadline(-1); err == nil {
+		t.Error("validateDeadline(-1): expected error")
+	}
+	if err := validateDeadline(0); err != nil {
+		t.Errorf("validateDeadline(0): expected ok, got %v", err)
+	}
+	if err := validateDeadline(60); err != nil {
+		t.Errorf("validateDeadline(60): expected ok, got %v", err)
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"example.com", "example.com"},
+		{"\x1b[2J\rexample.com", "?[2J?example.com"},
+		{"a\tb\nc", "a?b?c"},
+		{"127.0.0.1", "127.0.0.1"},
+		{"del\x7fete", "del?ete"},
+	}
+	for _, c := range cases {
+		if got := sanitize(c.in); got != c.want {
+			t.Errorf("sanitize(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSampleRingUnderCap(t *testing.T) {
+	r := newSampleRing(5)
+	for _, v := range []float64{1, 2, 3} {
+		r.add(v)
+	}
+	got := r.values()
+	if len(got) != 3 || got[0] != 1 || got[2] != 3 {
+		t.Errorf("under-cap values = %v, want [1 2 3]", got)
+	}
+	if r.full {
+		t.Error("ring should not be full under cap")
+	}
+}
+
+func TestSampleRingOverflow(t *testing.T) {
+	r := newSampleRing(3)
+	for _, v := range []float64{1, 2, 3, 4, 5} {
+		r.add(v)
+	}
+	got := r.values()
+	// After 5 adds into cap 3, the window is [3, 4, 5] (oldest evicted).
+	if len(got) != 3 || got[0] != 3 || got[1] != 4 || got[2] != 5 {
+		t.Errorf("overflow values = %v, want [3 4 5]", got)
+	}
+	if !r.full {
+		t.Error("ring should be full after overflow")
+	}
+}
+
+func TestSampleRingCapGuard(t *testing.T) {
+	r := newSampleRing(0) // must be coerced to >= 1
+	r.add(42)
+	if got := r.values(); len(got) != 1 || got[0] != 42 {
+		t.Errorf("cap-guard values = %v, want [42]", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes out the remaining Medium/Low findings from the security review. No regression for normal usage; long and infinite runs are now memory-bounded and cleanly stoppable.

## Changes

### M3 — Bounded memory
- RTT samples stored in a fixed-capacity **ring buffer** (`maxSamples = 100000`). Infinite runs no longer grow memory without bound.
- `Probes sent` / `Successful responses` / `% failed` remain full-run counters; `min/max/median/percentiles/average` are computed over the retained window.

### M2 — Robust stopping
- New **`-deadline`** flag (seconds): stops and prints results when reached.
- `signal.Notify` now catches **`SIGTERM`** in addition to `SIGINT`, so `kill` / process managers / `docker stop` exit cleanly with results.
- Interruptible sleep is used for **all** runs (finite too), so a long finite run can also be Ctrl+C'd with a summary.
- Replaced `os.Exit`-based signal handling with a single labeled-loop break → one `output()` path.

### L1 — Output sanitization
- Display hostname is sanitized (control chars → `?`) to prevent ANSI / log-line injection.

### L4 / M5 — Packaging & CI
- Fixed the **module path** to `github.com/pjperez/gotcping` so `go install …@latest` works. README install section + `-deadline` documented.
- Added **`.github/workflows/ci.yml`**: `go vet`, `go build`, `go test`, `govulncheck` on push + PR.

### Tests
- `validatePort` / `validateTimeout` / `validateDeadline`, `sanitize`, and the `sampleRing` (under-cap, overflow, zero-cap guard).

## Verification

| Check | Result |
|---|---|
| `go build ./...` | ✅ |
| `go vet ./...` | ✅ clean |
| `go test ./...` | ✅ all pass |
| `govulncheck ./...` | ✅ 0 vulnerabilities in code path |
| smoke: `-count 0 -deadline 3` | ✅ stops at 3s, prints results (3 probes) |
| smoke: `-deadline -1` | ✅ `error: deadline must be >= 0`, exit 1 |

## Notes
- M4 (int overflow of the loop counter) is moot on 64-bit platforms (would take ~10¹¹ years) and the only unbounded state — the samples slice — is now ring-bounded, so it is not addressed separately.

CI will run on this PR; I'll merge once it's green.